### PR TITLE
fix unthread safe memory allocation

### DIFF
--- a/src/setup_generic.c
+++ b/src/setup_generic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016, Matthias Rottmann, Artur Strebel, Simon Heybrock, Simone Bacchio, Bjoern Leder, Issaku Kanamori.
+ * Copyright (C) 2017, Matthias Rottmann, Artur Strebel, Simon Heybrock, Simone Bacchio, Bjoern Leder, Issaku Kanamori.
  * 
  * This file is part of the DDalphaAMG solver library.
  * 
@@ -198,7 +198,7 @@ void interpolation_PRECISION_define( vector_double *V, level_struct *l, struct T
     
   if ( V == NULL ) {
     
-    PUBLIC_MALLOC( buffer, complex_PRECISION*, 3 );
+    MALLOC( buffer, complex_PRECISION*, 3 );
     buffer[0] = NULL;
     PUBLIC_MALLOC( buffer[0], complex_PRECISION, l->vector_size*3 );
     
@@ -234,7 +234,7 @@ void interpolation_PRECISION_define( vector_double *V, level_struct *l, struct T
     }
     
     PUBLIC_FREE( buffer[0], complex_PRECISION, l->vector_size*3 );
-    PUBLIC_FREE( buffer, complex_PRECISION*, 3 );
+    FREE( buffer, complex_PRECISION*, 3 );
     
     for ( k=0; k<n; k++ ) {
       vector_PRECISION_real_scale( l->is_PRECISION.test_vector[k], l->is_PRECISION.test_vector[k],


### PR DESCRIPTION
Hi Matthias,

I found an unthread safe memory allocation in
  void interpolation_PRECISION_define( ... ) in setup_generic.c,
which sometimes caused segmentation faults in my environment.   Depending on the timing, any thread/core can overwrite buffer[0] with NULL after the master allocated the memory to buffer[0].
Could you have a look at my change?  I wander other users might be suffering from the same problem.  
Thanks a lot!

Issaku